### PR TITLE
Reformat icon submission notice in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@
 
 <h3 align="center">Powered by Cloudflare Workers ⚡</h3>
 
-<h3>NOTE: To keep icons consistent and to ensure browser support, we don't accept pull requests for icon submissions. If you would like an icon added, please open an issue.<h3>
+> [!NOTE]  
+> To keep icons consistent and ensure browser support, we don't accept pull requests for icon submissions. If you would like an icon added, please [open an issue](https://github.com/tandpfun/skill-icons/issues/new/choose).
 
 # Docs
 


### PR DESCRIPTION
Reformatted the original notice about icon submissions to follow GitHub's cleaner "alert" syntax. It now displays as shown:

> [!NOTE]  
> To keep icons consistent and ensure browser support, we don't accept pull requests for icon submissions. If you would like an icon added, please [open an issue](https://github.com/tandpfun/skill-icons/issues/new/choose).

Additionally, a hyperlink to directly open an issue was added. This is a very minor and insignificant pull request, but I thought it looks much cleaner than the current header that's identical to the others. No content was changed besides a minor grammar fix.

If this is something you like the look of better, I hope it is useful!