### PR TITLE
Updated iconParam Splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
+public/build/
+public/temp/
+public/*.log
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
@@ -93,9 +97,6 @@ dist
 
 # Gatsby files
 .cache/
-# Comment in the public line in if your project uses Gatsby and not Next.js
-# https://nextjs.org/blog/next-9-1#public-directory-support
-# public
 
 # vuepress build output
 .vuepress/dist

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ async function handleRequest(request) {
 
     let iconShortNames = [];
     if (iconParam === 'all') iconShortNames = iconNameList;
-    else iconShortNames = iconParam.split(',');
+    else iconShortNames = iconParam.split(/,\s*/);
 
     const iconNames = parseShortNames(iconShortNames, theme || undefined);
     if (!iconNames)

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,11 @@
+
+<h4 align="center"><em>This is a fork of the <a href="https://github.com/tandpfun/skill-icons">original skill icons</a> since it has been abandoned.</em></3>
+
 <p align="center"><img align="center" width="280" src="./.github/text-logo.svg#gh-dark-mode-only"/></p>
 <p align="center"><img align="center" width="280" src="./.github/text-logo-light.svg#gh-light-mode-only"/></p>
 <h3 align="center">Showcase your skills on your GitHub or resumé with ease!</h3>
 <hr>
 
-<h3 align="center">Powered by Cloudflare Workers ⚡</h3>
 
 <h3>NOTE: To keep icons consistent and to ensure browser support, we don't accept pull requests for icon submissions. If you would like an icon added, please open an issue.<h3>
 

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 
-<h4 align="center"><em>This is a fork of the <a href="https://github.com/tandpfun/skill-icons">original skill icons</a> since it has been abandoned.</em></3>
 
 <p align="center"><img align="center" width="280" src="./.github/text-logo.svg#gh-dark-mode-only"/></p>
 <p align="center"><img align="center" width="280" src="./.github/text-logo-light.svg#gh-light-mode-only"/></p>
 <h3 align="center">Showcase your skills on your GitHub or resumé with ease!</h3>
+<h4 align="center"><em>This is a fork of the <a href="https://github.com/tandpfun/skill-icons">original skill icons</a> since it has been abandoned.</em></3>
 <hr>
 
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@
 
 Copy and paste the code block below into your readme to add the skills icon element!
 
-Change the `?i=js,html,css` to a list of your skills separated by ","s! You can find a full list of icons [here](#icons-list).
+Change the `?i=js,html,css` to a list of your skills separated by "," or ", "! You can find a full list of icons [here](#icons-list).
 
 ```md
 [![My Skills](https://skillicons.dev/icons?i=js,html,css,wasm)](https://skillicons.dev)

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,8 @@
 <p align="center"><img align="center" width="280" src="./.github/text-logo.svg#gh-dark-mode-only"/></p>
 <p align="center"><img align="center" width="280" src="./.github/text-logo-light.svg#gh-light-mode-only"/></p>
 <h3 align="center">Showcase your skills on your GitHub or resumé with ease!</h3>
-<h4 align="center"><em>This is a fork of the <a href="https://github.com/tandpfun/skill-icons">original skill icons</a> since it has been abandoned.</em></3>
+<h4 align="center"><em>This is a fork of the <a href="https://github.com/tandpfun/skill-icons">original skill icons</a> since it has been abandoned.</em></h4>
+<h5 align="center">In process of bringing it back</p>
 <hr>
 
 


### PR DESCRIPTION
Simple change to allow lists like this: "js, html, css" since its very common to instinctively press space after commas. 