### PR TITLE
Added Shadcn Icon Light/Dark

### DIFF
--- a/icons/Shadcn-Dark.svg
+++ b/icons/Shadcn-Dark.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+  <g id="Layer_1" transform="matrix(1.971072, 0, 0, 1.971072, -451.910963, -122.302692)" style="">
+    <rect class="st0" width="256" height="256" style="stroke-width: 1;" x="228.027" y="59.695" rx="65.913" ry="65.913"/>
+    <line class="st1" x1="436.027" y1="187.695" x2="356.027" y2="267.695" style="stroke-linecap: round; stroke-linejoin: round; stroke-width: 32; paint-order: fill; fill-rule: nonzero; fill: rgb(255, 255, 255); stroke: rgb(255, 255, 255);"/>
+    <line class="st1" x1="420.027" y1="99.695" x2="268.027" y2="251.695" style="stroke-linecap: round; stroke-linejoin: round; stroke-width: 32; fill: rgb(153, 183, 59); stroke: rgb(255, 255, 255);"/>
+  </g>
+</svg>

--- a/icons/Shadcn-Light.svg
+++ b/icons/Shadcn-Light.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+  <g id="Layer_1" style="" transform="matrix(1.956434, 0, 0, 1.956434, -231.626792, -244.045738)">
+    <rect class="st0" width="256" height="256" style="stroke-width: 1; fill: rgb(255, 255, 255);" x="118.096" y="124.55" rx="66.087" ry="66.087"/>
+    <line class="st1" x1="326.096" y1="252.55" x2="246.096" y2="332.55" style="stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 32; fill: rgb(255, 255, 255);"/>
+    <line class="st1" x1="310.096" y1="164.55" x2="158.096" y2="316.55" style="stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 32; fill: rgb(255, 255, 255);"/>
+  </g>
+</svg>

--- a/readme.md
+++ b/readme.md
@@ -281,6 +281,7 @@ Here's a list of all the icons currently supported. Feel free to open an issue t
 |     `selenium`     |      <img src="./icons/Selenium.svg" width="48">      |
 |      `sentry`      |       <img src="./icons/Sentry.svg" width="48">       |
 |    `sequelize`     |   <img src="./icons/Sequelize-Dark.svg" width="48">   |
+|      `shadcn`      |   <img src="./icons/Shadcn-Dark.svg" width="48">      |
 |     `sketchup`     |   <img src="./icons/Sketchup-Dark.svg" width="48">    |
 |     `solidity`     |      <img src="./icons/Solidity.svg" width="48">      |
 |     `solidjs`      |    <img src="./icons/SolidJS-Dark.svg" width="48">    |


### PR DESCRIPTION
### Add Shadcn Icon (Light/Dark) to Skill Icons

**Date:** July 7, 2025  
**Developer:** John Paul Miraflores `daxxtropezz`

**Request Creation:**
- Added `shadcn-light` and `shadcn-dark` SVG icons to the [skill-icons](https://github.com/tandpfun/skill-icons) GitHub repository

**Update:**
- Submitted a pull request to include Shadcn UI branding in the skill icon library